### PR TITLE
fix(ts): release owned ImageBitmaps after encodeImage

### DIFF
--- a/packages/arthash-ts/src/index.ts
+++ b/packages/arthash-ts/src/index.ts
@@ -792,47 +792,55 @@ async function imageToThumbRgb(
     );
   }
 
-  let bitmap: ImageBitmap;
-  if (typeof source === "string") {
-    const blob = await (await fetch(source)).blob();
-    bitmap = await createImageBitmap(blob);
-  } else if (source instanceof Blob) {
-    bitmap = await createImageBitmap(source);
-  } else if ((source as ImageBitmap).width !== undefined && (source as ImageBitmap).close) {
-    bitmap = source as ImageBitmap;
-  } else {
-    bitmap = await createImageBitmap(source as HTMLImageElement);
-  }
+  let bitmap: ImageBitmap | undefined;
+  let ownsBitmap = false;
+  try {
+    if (typeof source === "string") {
+      const blob = await (await fetch(source)).blob();
+      bitmap = await createImageBitmap(blob);
+      ownsBitmap = true;
+    } else if (source instanceof Blob) {
+      bitmap = await createImageBitmap(source);
+      ownsBitmap = true;
+    } else if ((source as ImageBitmap).width !== undefined && (source as ImageBitmap).close) {
+      bitmap = source as ImageBitmap;
+    } else {
+      bitmap = await createImageBitmap(source as HTMLImageElement);
+      ownsBitmap = true;
+    }
 
-  const sw = bitmap.width;
-  const sh = bitmap.height;
-  let w: number, h: number;
-  const longest = Math.max(sw, sh);
-  if (longest <= target) {
-    w = sw;
-    h = sh;
-  } else if (sw >= sh) {
-    w = target;
-    h = Math.max(1, Math.round((target * sh) / sw));
-  } else {
-    h = target;
-    w = Math.max(1, Math.round((target * sw) / sh));
-  }
+    const sw = bitmap.width;
+    const sh = bitmap.height;
+    let w: number, h: number;
+    const longest = Math.max(sw, sh);
+    if (longest <= target) {
+      w = sw;
+      h = sh;
+    } else if (sw >= sh) {
+      w = target;
+      h = Math.max(1, Math.round((target * sh) / sw));
+    } else {
+      h = target;
+      w = Math.max(1, Math.round((target * sw) / sh));
+    }
 
-  const canvas = document.createElement("canvas");
-  canvas.width = w;
-  canvas.height = h;
-  const ctx = canvas.getContext("2d", { willReadFrequently: true });
-  if (!ctx) throw new Error("arthash.encodeImage: 2D canvas context unavailable");
-  ctx.imageSmoothingEnabled = true;
-  ctx.imageSmoothingQuality = "high";
-  ctx.drawImage(bitmap, 0, 0, w, h);
-  const { data } = ctx.getImageData(0, 0, w, h);
-  const rgb = new Uint8Array(w * h * 3);
-  for (let i = 0, j = 0; i < data.length; i += 4, j += 3) {
-    rgb[j] = data[i]!;
-    rgb[j + 1] = data[i + 1]!;
-    rgb[j + 2] = data[i + 2]!;
+    const canvas = document.createElement("canvas");
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext("2d", { willReadFrequently: true });
+    if (!ctx) throw new Error("arthash.encodeImage: 2D canvas context unavailable");
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = "high";
+    ctx.drawImage(bitmap, 0, 0, w, h);
+    const { data } = ctx.getImageData(0, 0, w, h);
+    const rgb = new Uint8Array(w * h * 3);
+    for (let i = 0, j = 0; i < data.length; i += 4, j += 3) {
+      rgb[j] = data[i]!;
+      rgb[j + 1] = data[i + 1]!;
+      rgb[j + 2] = data[i + 2]!;
+    }
+    return { rgb, w, h };
+  } finally {
+    if (ownsBitmap) bitmap?.close();
   }
-  return { rgb, w, h };
 }

--- a/packages/arthash-ts/test/encode-image.test.ts
+++ b/packages/arthash-ts/test/encode-image.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Vitest supports virtual mocks at runtime for this generated WASM module,
+// but the installed type declarations only expose the two-argument overload.
+vi.mock(
+  "../wasm/pkg/arthash_wasm.js",
+  () => ({
+    default: vi.fn(async () => undefined),
+    encodeRgb: vi.fn(() => new Uint8Array([0])),
+    encodeRgba: vi.fn(() => new Uint8Array([0])),
+    decode: vi.fn(),
+    toSvg: vi.fn(),
+  }),
+  // @ts-expect-error Vitest's runtime supports this virtual mock overload.
+  { virtual: true },
+);
+
+import { codec, encodeImage } from "../src/index.js";
+
+type FakeBitmap = ImageBitmap & {
+  close: ReturnType<typeof vi.fn>;
+};
+
+function fakeBitmap(): FakeBitmap {
+  return {
+    width: 2,
+    height: 1,
+    close: vi.fn(),
+  } as unknown as FakeBitmap;
+}
+
+function installCanvas(getImageData: () => { data: Uint8ClampedArray }) {
+  const context = {
+    imageSmoothingEnabled: false,
+    imageSmoothingQuality: "low" as ImageSmoothingQuality,
+    drawImage: vi.fn(),
+    getImageData: vi.fn(getImageData),
+  } as unknown as CanvasRenderingContext2D;
+  const canvas = {
+    width: 0,
+    height: 0,
+    getContext: vi.fn(() => context),
+  } as unknown as HTMLCanvasElement;
+
+  vi.stubGlobal("document", {
+    createElement: vi.fn(() => canvas),
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("encodeImage ImageBitmap ownership", () => {
+  it.each([
+    ["a URL", () => "https://example.test/image.png"],
+    ["a Blob", () => new Blob(["image"])],
+    ["an HTMLImageElement", () => ({}) as HTMLImageElement],
+  ])("closes the ImageBitmap it creates from %s", async (_label, source) => {
+    const bitmap = fakeBitmap();
+    const createImageBitmap = vi.fn(async () => bitmap);
+    vi.stubGlobal("createImageBitmap", createImageBitmap);
+    if (typeof source() === "string") {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async () => ({ blob: async () => new Blob(["image"]) })),
+      );
+    }
+    installCanvas(() => ({
+      data: new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255]),
+    }));
+
+    await expect(
+      encodeImage(source(), codec.pixel({ n: 4 }), { seed: 1 }),
+    ).resolves.toBeInstanceOf(Uint8Array);
+
+    expect(createImageBitmap).toHaveBeenCalledOnce();
+    expect(bitmap.close).toHaveBeenCalledOnce();
+  });
+
+  it("closes a library-created ImageBitmap when canvas processing throws", async () => {
+    const bitmap = fakeBitmap();
+    vi.stubGlobal("createImageBitmap", vi.fn(async () => bitmap));
+    installCanvas(() => {
+      throw new Error("pixel extraction failed");
+    });
+
+    await expect(
+      encodeImage(new Blob(["image"]), codec.pixel({ n: 4 }), { seed: 1 }),
+    ).rejects.toThrow("pixel extraction failed");
+
+    expect(bitmap.close).toHaveBeenCalledOnce();
+  });
+
+  it("leaves no library-created ImageBitmaps live after a batch", async () => {
+    const batchSize = 100;
+    const liveBitmaps = new Set<number>();
+    let created = 0;
+    let closed = 0;
+    vi.stubGlobal(
+      "createImageBitmap",
+      vi.fn(async () => {
+        const id = created++;
+        liveBitmaps.add(id);
+        const bitmap = fakeBitmap();
+        bitmap.close = vi.fn(() => {
+          closed++;
+          liveBitmaps.delete(id);
+        });
+        return bitmap;
+      }),
+    );
+    installCanvas(() => ({
+      data: new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255]),
+    }));
+
+    for (let i = 0; i < batchSize; i++) {
+      await encodeImage(new Blob(["image"]), codec.pixel({ n: 4 }), {
+        seed: 1,
+      });
+    }
+
+    // This is the deterministic equivalent of watching GPU resources grow:
+    // the buggy implementation reports live=100, while the fixed one reports
+    // created=100, closed=100, live=0.
+    expect({ created, closed, live: liveBitmaps.size }).toEqual({
+      created: batchSize,
+      closed: batchSize,
+      live: 0,
+    });
+  });
+
+  it("does not close an ImageBitmap supplied by the caller", async () => {
+    const bitmap = fakeBitmap();
+    const createImageBitmap = vi.fn();
+    vi.stubGlobal("createImageBitmap", createImageBitmap);
+    installCanvas(() => ({
+      data: new Uint8ClampedArray([255, 0, 0, 255, 0, 255, 0, 255]),
+    }));
+
+    await expect(
+      encodeImage(bitmap, codec.pixel({ n: 4 }), { seed: 1 }),
+    ).resolves.toBeInstanceOf(Uint8Array);
+
+    expect(createImageBitmap).not.toHaveBeenCalled();
+    expect(bitmap.close).not.toHaveBeenCalled();
+  });
+});

--- a/packages/arthash-ts/test/encode-image.test.ts
+++ b/packages/arthash-ts/test/encode-image.test.ts
@@ -1,19 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-// Vitest supports virtual mocks at runtime for this generated WASM module,
-// but the installed type declarations only expose the two-argument overload.
-vi.mock(
-  "../wasm/pkg/arthash_wasm.js",
-  () => ({
-    default: vi.fn(async () => undefined),
-    encodeRgb: vi.fn(() => new Uint8Array([0])),
-    encodeRgba: vi.fn(() => new Uint8Array([0])),
-    decode: vi.fn(),
-    toSvg: vi.fn(),
-  }),
-  // @ts-expect-error Vitest's runtime supports this virtual mock overload.
-  { virtual: true },
-);
+// Mock the generated wasm boundary so this suite only exercises the DOM /
+// ImageBitmap plumbing. `wasm/pkg` always exists here: CI runs `build`
+// before `test`.
+vi.mock("../wasm/pkg/arthash_wasm.js", () => ({
+  default: vi.fn(async () => undefined),
+  encodeRgb: vi.fn(() => new Uint8Array([0])),
+  encodeRgba: vi.fn(() => new Uint8Array([0])),
+  decode: vi.fn(),
+  toSvg: vi.fn(),
+}));
 
 import { codec, encodeImage } from "../src/index.js";
 


### PR DESCRIPTION
## Summary

- Release `ImageBitmap` instances created by `encodeImage()` from URL, Blob, and HTML image inputs.
- Keep caller-owned `ImageBitmap` instances open.
- Release library-owned bitmaps on both success and canvas-processing exceptions.
- Add deterministic regression coverage for all input paths, exception cleanup, caller ownership, and a 100-image batch.

## Evidence

The browser evidence harness executed the real `encodeImage()` implementation from both `main` and this fix branch with a real PNG Blob, `createImageBitmap()`, canvas, and 2D context. Only the WASM encoder boundary was mocked.

| Source | Created | Closed | Live after 100 calls |
| --- | ---: | ---: | ---: |
| `main` baseline | 100 | 0 | 100 |
| fix branch | 100 | 100 | 0 |

